### PR TITLE
Implemented sub-opcode

### DIFF
--- a/src/cpu/ops/handlers.rs
+++ b/src/cpu/ops/handlers.rs
@@ -35,6 +35,7 @@ const OP_CLR   : u32 = 0b0100_0010_0000_0000;
 const OP_CMP   : u32 = 0b1011_0000_0000_0000;
 const OP_CMPI  : u32 = 0b0000_1100_0000_0000;
 const OP_CMPM  : u32 = 0b1011_0001_0000_0000;
+const OP_SUB   : u32 = 0b1001_0000_0000_0000;
 
 const IF_T : u32 = 0b0000_0000_0000; // True                1
 const IF_F : u32 = 0b0001_0000_0000; // False                0
@@ -608,6 +609,69 @@ pub const OP_CMPM_8        : u32 = OP_CMPM | BYTE_SIZED | MM_MODE;
 pub const OP_CMPM_16       : u32 = OP_CMPM | WORD_SIZED | MM_MODE;
 pub const OP_CMPM_32       : u32 = OP_CMPM | LONG_SIZED | MM_MODE;
 
+pub const OP_SUB_8_ER_DN   : u32 = OP_SUB | BYTE_SIZED | DEST_DX | OPER_DN;
+pub const OP_SUB_8_ER_AI   : u32 = OP_SUB | BYTE_SIZED | DEST_DX | OPER_AI;
+pub const OP_SUB_8_ER_PI   : u32 = OP_SUB | BYTE_SIZED | DEST_DX | OPER_PI;
+pub const OP_SUB_8_ER_PD   : u32 = OP_SUB | BYTE_SIZED | DEST_DX | OPER_PD;
+pub const OP_SUB_8_ER_DI   : u32 = OP_SUB | BYTE_SIZED | DEST_DX | OPER_DI;
+pub const OP_SUB_8_ER_IX   : u32 = OP_SUB | BYTE_SIZED | DEST_DX | OPER_IX;
+pub const OP_SUB_8_ER_AW   : u32 = OP_SUB | BYTE_SIZED | DEST_DX | OPER_AW;
+pub const OP_SUB_8_ER_AL   : u32 = OP_SUB | BYTE_SIZED | DEST_DX | OPER_AL;
+pub const OP_SUB_8_ER_PCDI : u32 = OP_SUB | BYTE_SIZED | DEST_DX | OPER_PCDI;
+pub const OP_SUB_8_ER_PCIX : u32 = OP_SUB | BYTE_SIZED | DEST_DX | OPER_PCIX;
+pub const OP_SUB_8_ER_IMM  : u32 = OP_SUB | BYTE_SIZED | DEST_DX | OPER_IMM;
+
+pub const OP_SUB_8_RE_AI   : u32 = OP_SUB | BYTE_SIZED | DEST_EA | OPER_AI;
+pub const OP_SUB_8_RE_PI   : u32 = OP_SUB | BYTE_SIZED | DEST_EA | OPER_PI;
+pub const OP_SUB_8_RE_PD   : u32 = OP_SUB | BYTE_SIZED | DEST_EA | OPER_PD;
+pub const OP_SUB_8_RE_DI   : u32 = OP_SUB | BYTE_SIZED | DEST_EA | OPER_DI;
+pub const OP_SUB_8_RE_IX   : u32 = OP_SUB | BYTE_SIZED | DEST_EA | OPER_IX;
+pub const OP_SUB_8_RE_AW   : u32 = OP_SUB | BYTE_SIZED | DEST_EA | OPER_AW;
+pub const OP_SUB_8_RE_AL   : u32 = OP_SUB | BYTE_SIZED | DEST_EA | OPER_AL;
+
+pub const OP_SUB_16_ER_DN  : u32 = OP_SUB | WORD_SIZED | DEST_DX | OPER_DN;
+pub const OP_SUB_16_ER_AN  : u32 = OP_SUB | WORD_SIZED | DEST_DX | OPER_AN;
+pub const OP_SUB_16_ER_AI  : u32 = OP_SUB | WORD_SIZED | DEST_DX | OPER_AI;
+pub const OP_SUB_16_ER_PI  : u32 = OP_SUB | WORD_SIZED | DEST_DX | OPER_PI;
+pub const OP_SUB_16_ER_PD  : u32 = OP_SUB | WORD_SIZED | DEST_DX | OPER_PD;
+pub const OP_SUB_16_ER_DI  : u32 = OP_SUB | WORD_SIZED | DEST_DX | OPER_DI;
+pub const OP_SUB_16_ER_IX  : u32 = OP_SUB | WORD_SIZED | DEST_DX | OPER_IX;
+pub const OP_SUB_16_ER_AW  : u32 = OP_SUB | WORD_SIZED | DEST_DX | OPER_AW;
+pub const OP_SUB_16_ER_AL  : u32 = OP_SUB | WORD_SIZED | DEST_DX | OPER_AL;
+pub const OP_SUB_16_ER_PCDI: u32 = OP_SUB | WORD_SIZED | DEST_DX | OPER_PCDI;
+pub const OP_SUB_16_ER_PCIX: u32 = OP_SUB | WORD_SIZED | DEST_DX | OPER_PCIX;
+pub const OP_SUB_16_ER_IMM : u32 = OP_SUB | WORD_SIZED | DEST_DX | OPER_IMM;
+
+pub const OP_SUB_16_RE_AI  : u32 = OP_SUB | WORD_SIZED | DEST_EA | OPER_AI;
+pub const OP_SUB_16_RE_PI  : u32 = OP_SUB | WORD_SIZED | DEST_EA | OPER_PI;
+pub const OP_SUB_16_RE_PD  : u32 = OP_SUB | WORD_SIZED | DEST_EA | OPER_PD;
+pub const OP_SUB_16_RE_DI  : u32 = OP_SUB | WORD_SIZED | DEST_EA | OPER_DI;
+pub const OP_SUB_16_RE_IX  : u32 = OP_SUB | WORD_SIZED | DEST_EA | OPER_IX;
+pub const OP_SUB_16_RE_AW  : u32 = OP_SUB | WORD_SIZED | DEST_EA | OPER_AW;
+pub const OP_SUB_16_RE_AL  : u32 = OP_SUB | WORD_SIZED | DEST_EA | OPER_AL;
+
+pub const OP_SUB_32_ER_DN  : u32 = OP_SUB | LONG_SIZED | DEST_DX | OPER_DN;
+pub const OP_SUB_32_ER_AN  : u32 = OP_SUB | LONG_SIZED | DEST_DX | OPER_AN;
+pub const OP_SUB_32_ER_AI  : u32 = OP_SUB | LONG_SIZED | DEST_DX | OPER_AI;
+pub const OP_SUB_32_ER_PI  : u32 = OP_SUB | LONG_SIZED | DEST_DX | OPER_PI;
+pub const OP_SUB_32_ER_PD  : u32 = OP_SUB | LONG_SIZED | DEST_DX | OPER_PD;
+pub const OP_SUB_32_ER_DI  : u32 = OP_SUB | LONG_SIZED | DEST_DX | OPER_DI;
+pub const OP_SUB_32_ER_IX  : u32 = OP_SUB | LONG_SIZED | DEST_DX | OPER_IX;
+pub const OP_SUB_32_ER_AW  : u32 = OP_SUB | LONG_SIZED | DEST_DX | OPER_AW;
+pub const OP_SUB_32_ER_AL  : u32 = OP_SUB | LONG_SIZED | DEST_DX | OPER_AL;
+pub const OP_SUB_32_ER_PCDI: u32 = OP_SUB | LONG_SIZED | DEST_DX | OPER_PCDI;
+pub const OP_SUB_32_ER_PCIX: u32 = OP_SUB | LONG_SIZED | DEST_DX | OPER_PCIX;
+pub const OP_SUB_32_ER_IMM : u32 = OP_SUB | LONG_SIZED | DEST_DX | OPER_IMM;
+
+pub const OP_SUB_32_RE_AI  : u32 = OP_SUB | LONG_SIZED | DEST_EA | OPER_AI;
+pub const OP_SUB_32_RE_PI  : u32 = OP_SUB | LONG_SIZED | DEST_EA | OPER_PI;
+pub const OP_SUB_32_RE_PD  : u32 = OP_SUB | LONG_SIZED | DEST_EA | OPER_PD;
+pub const OP_SUB_32_RE_DI  : u32 = OP_SUB | LONG_SIZED | DEST_EA | OPER_DI;
+pub const OP_SUB_32_RE_IX  : u32 = OP_SUB | LONG_SIZED | DEST_EA | OPER_IX;
+pub const OP_SUB_32_RE_AW  : u32 = OP_SUB | LONG_SIZED | DEST_EA | OPER_AW;
+pub const OP_SUB_32_RE_AL  : u32 = OP_SUB | LONG_SIZED | DEST_EA | OPER_AL;
+
+
 pub fn generate() -> InstructionSet {
     // Covers all possible IR values (64k entries)
     let mut handler: InstructionSet = Vec::with_capacity(0x10000);
@@ -1125,6 +1189,67 @@ pub fn generate() -> InstructionSet {
         op_entry!(MASK_OUT_X_Y, OP_CMPM_16, cmpm_16),
         op_entry!(MASK_OUT_X_Y, OP_CMPM_32, cmpm_32),
 
+        op_entry!(MASK_OUT_X_Y, OP_SUB_8_ER_DN,   sub_8_er_dn),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_8_ER_AI,   sub_8_er_ai),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_8_ER_PI,   sub_8_er_pi),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_8_ER_PD,   sub_8_er_pd),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_8_ER_DI,   sub_8_er_di),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_8_ER_IX,   sub_8_er_ix),
+        op_entry!(MASK_OUT_X,   OP_SUB_8_ER_AW,   sub_8_er_aw),
+        op_entry!(MASK_OUT_X,   OP_SUB_8_ER_AL,   sub_8_er_al),
+        op_entry!(MASK_OUT_X,   OP_SUB_8_ER_PCDI, sub_8_er_pcdi),
+        op_entry!(MASK_OUT_X,   OP_SUB_8_ER_PCIX, sub_8_er_pcix),
+        op_entry!(MASK_OUT_X,   OP_SUB_8_ER_IMM,  sub_8_er_imm),
+
+        op_entry!(MASK_OUT_X_Y, OP_SUB_8_RE_AI,   sub_8_re_ai),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_8_RE_PI,   sub_8_re_pi),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_8_RE_PD,   sub_8_re_pd),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_8_RE_DI,   sub_8_re_di),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_8_RE_IX,   sub_8_re_ix),
+        op_entry!(MASK_OUT_X,   OP_SUB_8_RE_AW,   sub_8_re_aw),
+        op_entry!(MASK_OUT_X,   OP_SUB_8_RE_AL,   sub_8_re_al),
+
+        op_entry!(MASK_OUT_X_Y, OP_SUB_16_ER_DN,   sub_16_er_dn),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_16_ER_AN,   sub_16_er_an),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_16_ER_AI,   sub_16_er_ai),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_16_ER_PI,   sub_16_er_pi),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_16_ER_PD,   sub_16_er_pd),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_16_ER_DI,   sub_16_er_di),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_16_ER_IX,   sub_16_er_ix),
+        op_entry!(MASK_OUT_X,   OP_SUB_16_ER_AW,   sub_16_er_aw),
+        op_entry!(MASK_OUT_X,   OP_SUB_16_ER_AL,   sub_16_er_al),
+        op_entry!(MASK_OUT_X,   OP_SUB_16_ER_PCDI, sub_16_er_pcdi),
+        op_entry!(MASK_OUT_X,   OP_SUB_16_ER_PCIX, sub_16_er_pcix),
+        op_entry!(MASK_OUT_X,   OP_SUB_16_ER_IMM,  sub_16_er_imm),
+
+        op_entry!(MASK_OUT_X_Y, OP_SUB_16_RE_AI,   sub_16_re_ai),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_16_RE_PI,   sub_16_re_pi),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_16_RE_PD,   sub_16_re_pd),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_16_RE_DI,   sub_16_re_di),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_16_RE_IX,   sub_16_re_ix),
+        op_entry!(MASK_OUT_X,   OP_SUB_16_RE_AW,   sub_16_re_aw),
+        op_entry!(MASK_OUT_X,   OP_SUB_16_RE_AL,   sub_16_re_al),
+
+        op_entry!(MASK_OUT_X_Y, OP_SUB_32_ER_DN,   sub_32_er_dn),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_32_ER_AN,   sub_32_er_an),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_32_ER_AI,   sub_32_er_ai),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_32_ER_PI,   sub_32_er_pi),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_32_ER_PD,   sub_32_er_pd),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_32_ER_DI,   sub_32_er_di),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_32_ER_IX,   sub_32_er_ix),
+        op_entry!(MASK_OUT_X,   OP_SUB_32_ER_AW,   sub_32_er_aw),
+        op_entry!(MASK_OUT_X,   OP_SUB_32_ER_AL,   sub_32_er_al),
+        op_entry!(MASK_OUT_X,   OP_SUB_32_ER_PCDI, sub_32_er_pcdi),
+        op_entry!(MASK_OUT_X,   OP_SUB_32_ER_PCIX, sub_32_er_pcix),
+        op_entry!(MASK_OUT_X,   OP_SUB_32_ER_IMM,  sub_32_er_imm),
+
+        op_entry!(MASK_OUT_X_Y, OP_SUB_32_RE_AI,   sub_32_re_ai),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_32_RE_PI,   sub_32_re_pi),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_32_RE_PD,   sub_32_re_pd),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_32_RE_DI,   sub_32_re_di),
+        op_entry!(MASK_OUT_X_Y, OP_SUB_32_RE_IX,   sub_32_re_ix),
+        op_entry!(MASK_OUT_X,   OP_SUB_32_RE_AW,   sub_32_re_aw),
+        op_entry!(MASK_OUT_X,   OP_SUB_32_RE_AL,   sub_32_re_al),
     ];
     // let mut implemented = 0;
     for op in optable {

--- a/src/cpu/ops/mod.rs
+++ b/src/cpu/ops/mod.rs
@@ -1177,7 +1177,105 @@ cmpi_32!(cmpi_32_al, al_32,     12+16);
 // cmpi_32!(cmpi_32_pcdi, pcdi_32, 12+12); not present on 68000
 // cmpi_32!(cmpi_32_pcix, pcix_32, 12+14); not present on 68000
 // cmpi_32!(..., imm) not present
+//
 
 impl_op!(-, cmp_8,  cmpm_8, ay_pi_8, ax_pi_8, 12);
 impl_op!(-, cmp_16, cmpm_16, ay_pi_16, ax_pi_16, 12);
 impl_op!(-, cmp_32, cmpm_32, ay_pi_32, ax_pi_32, 20);
+
+macro_rules! sub_8_er {
+    ($name:ident, $src:ident, $cycles:expr) => (impl_op!(8, sub_8, $name, $src, dx, $cycles);)
+}
+macro_rules! sub_8_re {
+    ($name:ident, $dst:ident, $cycles:expr) => (impl_op!(8, sub_8, $name, dx, $dst, $cycles);)
+}
+macro_rules! sub_16_er {
+    ($name:ident, $src:ident, $cycles:expr) => (impl_op!(16, sub_16, $name, $src, dx, $cycles);)
+}
+macro_rules! sub_16_re {
+    ($name:ident, $dst:ident, $cycles:expr) => (impl_op!(16, sub_16, $name, dx, $dst, $cycles);)
+}
+macro_rules! sub_32_er {
+    ($name:ident, $src:ident, $cycles:expr) => (impl_op!(32, sub_32, $name, $src, dx, $cycles);)
+}
+macro_rules! sub_32_re {
+    ($name:ident, $dst:ident, $cycles:expr) => (impl_op!(32, sub_32, $name, dx, $dst, $cycles);)
+}
+sub_8_er!(sub_8_er_dn, dy, 4);
+// sub_8_er!(..., ay) not present - for word and long only
+sub_8_er!(sub_8_er_ai, ay_ai_8,   8);
+sub_8_er!(sub_8_er_pi, ay_pi_8,   8);
+sub_8_er!(sub_8_er_pd, ay_pd_8,  10);
+sub_8_er!(sub_8_er_di, ay_di_8,  12);
+sub_8_er!(sub_8_er_ix, ay_ix_8,  14);
+sub_8_er!(sub_8_er_aw, aw_8,     12);
+sub_8_er!(sub_8_er_al, al_8,     16);
+sub_8_er!(sub_8_er_pcdi, pcdi_8, 12);
+sub_8_er!(sub_8_er_pcix, pcix_8, 14);
+sub_8_er!(sub_8_er_imm, imm_8,   10);
+
+// sub_8_re!(..., dy) not present
+// sub_8_re!(..., ay) not present
+sub_8_re!(sub_8_re_ai, ea_ay_ai_8,  12);
+sub_8_re!(sub_8_re_pi, ea_ay_pi_8,  12);
+sub_8_re!(sub_8_re_pd, ea_ay_pd_8,  14);
+sub_8_re!(sub_8_re_di, ea_ay_di_8,  16);
+sub_8_re!(sub_8_re_ix, ea_ay_ix_8,  18);
+sub_8_re!(sub_8_re_aw, ea_aw_8,     16);
+sub_8_re!(sub_8_re_al, ea_al_8,     20);
+// sub_8_re!(..., pcdi) not present
+// sub_8_re!(..., pcix) not present
+// sub_8_re!(..., imm) not present
+
+sub_16_er!(sub_16_er_dn, dy,         4);
+sub_16_er!(sub_16_er_an, ay,         4);
+sub_16_er!(sub_16_er_ai, ay_ai_16,   8);
+sub_16_er!(sub_16_er_pi, ay_pi_16,   8);
+sub_16_er!(sub_16_er_pd, ay_pd_16,  10);
+sub_16_er!(sub_16_er_di, ay_di_16,  12);
+sub_16_er!(sub_16_er_ix, ay_ix_16,  14);
+sub_16_er!(sub_16_er_aw, aw_16,     12);
+sub_16_er!(sub_16_er_al, al_16,     16);
+sub_16_er!(sub_16_er_pcdi, pcdi_16, 12);
+sub_16_er!(sub_16_er_pcix, pcix_16, 14);
+sub_16_er!(sub_16_er_imm, imm_16,   10);
+
+// sub_16_re!(..., dy) not present
+// sub_16_re!(..., ay) not present
+sub_16_re!(sub_16_re_ai, ea_ay_ai_16,  12);
+sub_16_re!(sub_16_re_pi, ea_ay_pi_16,  12);
+sub_16_re!(sub_16_re_pd, ea_ay_pd_16,  14);
+sub_16_re!(sub_16_re_di, ea_ay_di_16,  16);
+sub_16_re!(sub_16_re_ix, ea_ay_ix_16,  18);
+sub_16_re!(sub_16_re_aw, ea_aw_16,     16);
+sub_16_re!(sub_16_re_al, ea_al_16,     20);
+// sub_16_re!(..., pcdi) not present
+// sub_16_re!(..., pcix) not present
+// sub_16_re!(..., imm) not present
+
+sub_32_er!(sub_32_er_dn, dy,         6);
+sub_32_er!(sub_32_er_an, ay,         6);
+sub_32_er!(sub_32_er_ai, ay_ai_32,  14);
+sub_32_er!(sub_32_er_pi, ay_pi_32,  14);
+sub_32_er!(sub_32_er_pd, ay_pd_32,  16);
+sub_32_er!(sub_32_er_di, ay_di_32,  18);
+sub_32_er!(sub_32_er_ix, ay_ix_32,  20);
+sub_32_er!(sub_32_er_aw, aw_32,     18);
+sub_32_er!(sub_32_er_al, al_32,     22);
+sub_32_er!(sub_32_er_pcdi, pcdi_32, 18);
+sub_32_er!(sub_32_er_pcix, pcix_32, 20);
+sub_32_er!(sub_32_er_imm, imm_32,   16);
+
+// sub_32_re!(..., dy) not present
+// sub_32_re!(..., ay) not present
+sub_32_re!(sub_32_re_ai, ea_ay_ai_32,  12+8);
+sub_32_re!(sub_32_re_pi, ea_ay_pi_32,  12+8);
+sub_32_re!(sub_32_re_pd, ea_ay_pd_32,  14+8);
+sub_32_re!(sub_32_re_di, ea_ay_di_32,  16+8);
+sub_32_re!(sub_32_re_ix, ea_ay_ix_32,  18+8);
+sub_32_re!(sub_32_re_aw, ea_aw_32,     16+8);
+sub_32_re!(sub_32_re_al, ea_al_32,     20+8);
+// sub_32_re!(..., pcdi) not present
+// sub_32_re!(..., pcix) not present
+// sub_32_re!(..., imm) not present
+

--- a/src/musashi.rs
+++ b/src/musashi.rs
@@ -1026,9 +1026,72 @@ mod tests {
     qc!(OP_CMPI_32_AW, MASK_EXACT,   qc_cmpi_32_aw);
     qc!(OP_CMPI_32_AL, MASK_EXACT,   qc_cmpi_32_al);
 
-    qc8!(OP_CMPM_8, MASK_OUT_X_Y,  qc_cmpm_8);
+    qc8!(OP_CMPM_8, MASK_OUT_X_Y, qc_cmpm_8);
     qc!(OP_CMPM_16, MASK_OUT_X_Y, qc_cmpm_16);
     qc!(OP_CMPM_32, MASK_OUT_X_Y, qc_cmpm_32);
+
+    qc8!(OP_SUB_8_ER_DN, qc_sub_8_er_dn);
+    qc8!(OP_SUB_8_ER_PI, qc_sub_8_er_pi);
+    qc8!(OP_SUB_8_ER_PD, qc_sub_8_er_pd);
+    qc8!(OP_SUB_8_ER_AI, qc_sub_8_er_ai);
+    qc8!(OP_SUB_8_ER_DI, qc_sub_8_er_di);
+    qc8!(OP_SUB_8_ER_IX, qc_sub_8_er_ix);
+    qc8!(OP_SUB_8_ER_AW,   MASK_OUT_X, qc_sub_8_er_aw);
+    qc8!(OP_SUB_8_ER_AL,   MASK_OUT_X, qc_sub_8_er_al);
+    qc8!(OP_SUB_8_ER_PCDI, MASK_OUT_X, qc_sub_8_er_pcdi);
+    qc8!(OP_SUB_8_ER_PCIX, MASK_OUT_X, qc_sub_8_er_pcix);
+    qc8!(OP_SUB_8_ER_IMM,  MASK_OUT_X, qc_sub_8_er_imm);
+
+    qc8!(OP_SUB_8_RE_PI, qc_sub_8_re_pi);
+    qc8!(OP_SUB_8_RE_PD, qc_sub_8_re_pd);
+    qc8!(OP_SUB_8_RE_AI, qc_sub_8_re_ai);
+    qc8!(OP_SUB_8_RE_DI, qc_sub_8_re_di);
+    qc8!(OP_SUB_8_RE_IX, qc_sub_8_re_ix);
+    qc8!(OP_SUB_8_RE_AW, MASK_OUT_X, qc_sub_8_re_aw);
+    qc8!(OP_SUB_8_RE_AL, MASK_OUT_X, qc_sub_8_re_al);
+
+    qc!(OP_SUB_16_ER_DN, qc_sub_16_er_dn);
+    qc!(OP_SUB_16_ER_AN, qc_sub_16_er_an);
+    qc!(OP_SUB_16_ER_PI, qc_sub_16_er_pi);
+    qc!(OP_SUB_16_ER_PD, qc_sub_16_er_pd);
+    qc!(OP_SUB_16_ER_AI, qc_sub_16_er_ai);
+    qc!(OP_SUB_16_ER_DI, qc_sub_16_er_di);
+    qc!(OP_SUB_16_ER_IX, qc_sub_16_er_ix);
+    qc!(OP_SUB_16_ER_AW,   MASK_OUT_X, qc_sub_16_er_aw);
+    qc!(OP_SUB_16_ER_AL,   MASK_OUT_X, qc_sub_16_er_al);
+    qc!(OP_SUB_16_ER_PCDI, MASK_OUT_X, qc_sub_16_er_pcdi);
+    qc!(OP_SUB_16_ER_PCIX, MASK_OUT_X, qc_sub_16_er_pcix);
+    qc!(OP_SUB_16_ER_IMM,  MASK_OUT_X, qc_sub_16_er_imm);
+
+    qc!(OP_SUB_16_RE_PI, qc_sub_16_re_pi);
+    qc!(OP_SUB_16_RE_PD, qc_sub_16_re_pd);
+    qc!(OP_SUB_16_RE_AI, qc_sub_16_re_ai);
+    qc!(OP_SUB_16_RE_DI, qc_sub_16_re_di);
+    qc!(OP_SUB_16_RE_IX, qc_sub_16_re_ix);
+    qc!(OP_SUB_16_RE_AW, MASK_OUT_X, qc_sub_16_re_aw);
+    qc!(OP_SUB_16_RE_AL, MASK_OUT_X, qc_sub_16_re_al);
+
+    qc!(OP_SUB_32_ER_DN, qc_sub_32_er_dn);
+    qc!(OP_SUB_32_ER_AN, qc_sub_32_er_an);
+    qc!(OP_SUB_32_ER_PI, qc_sub_32_er_pi);
+    qc!(OP_SUB_32_ER_PD, qc_sub_32_er_pd);
+    qc!(OP_SUB_32_ER_AI, qc_sub_32_er_ai);
+    qc!(OP_SUB_32_ER_DI, qc_sub_32_er_di);
+    qc!(OP_SUB_32_ER_IX, qc_sub_32_er_ix);
+    qc!(OP_SUB_32_ER_AW,   MASK_OUT_X, qc_sub_32_er_aw);
+    qc!(OP_SUB_32_ER_AL,   MASK_OUT_X, qc_sub_32_er_al);
+    qc!(OP_SUB_32_ER_PCDI, MASK_OUT_X, qc_sub_32_er_pcdi);
+    qc!(OP_SUB_32_ER_PCIX, MASK_OUT_X, qc_sub_32_er_pcix);
+    qc!(OP_SUB_32_ER_IMM,  MASK_OUT_X, qc_sub_32_er_imm);
+
+    qc!(OP_SUB_32_RE_PI, qc_sub_32_re_pi);
+    qc!(OP_SUB_32_RE_PD, qc_sub_32_re_pd);
+    qc!(OP_SUB_32_RE_AI, qc_sub_32_re_ai);
+    qc!(OP_SUB_32_RE_DI, qc_sub_32_re_di);
+    qc!(OP_SUB_32_RE_IX, qc_sub_32_re_ix);
+    qc!(OP_SUB_32_RE_AW, MASK_OUT_X, qc_sub_32_re_aw);
+    qc!(OP_SUB_32_RE_AL, MASK_OUT_X, qc_sub_32_re_al);
+
 
     macro_rules! core_eq {
         ($left:ident , $right:ident . $field:ident [ $index:expr ]) => ({


### PR DESCRIPTION
As detailed in https://github.com/marhel/r68k/issues/47

Passes qc test with qc_sub_8_er_dn qc_sub_8_er_pi qc_sub_8_er_pd qc_sub_8_er_ai qc_sub_8_er_di qc_sub_8_er_ix qc_sub_8_er_aw qc_sub_8_er_al qc_sub_8_er_pcdi qc_sub_8_er_pcix qc_sub_8_er_imm qc_sub_8_re_pi qc_sub_8_re_pd qc_sub_8_re_ai qc_sub_8_re_di qc_sub_8_re_ix qc_sub_8_re_aw qc_sub_8_re_al qc_sub_16_er_dn qc_sub_16_er_an qc_sub_16_er_pi qc_sub_16_er_pd qc_sub_16_er_ai qc_sub_16_er_di qc_sub_16_er_ix qc_sub_16_er_aw qc_sub_16_er_al qc_sub_16_er_pcdi qc_sub_16_er_pcix qc_sub_16_er_imm qc_sub_16_re_pi qc_sub_16_re_pd qc_sub_16_re_ai qc_sub_16_re_di qc_sub_16_re_ix qc_sub_16_re_aw qc_sub_16_re_al qc_sub_32_er_dn qc_sub_32_er_an qc_sub_32_er_pi qc_sub_32_er_pd qc_sub_32_er_ai qc_sub_32_er_di qc_sub_32_er_ix qc_sub_32_er_aw qc_sub_32_er_al qc_sub_32_er_pcdi qc_sub_32_er_pcix qc_sub_32_er_imm qc_sub_32_re_pi qc_sub_32_re_pd qc_sub_32_re_ai qc_sub_32_re_di qc_sub_32_re_ix qc_sub_32_re_aw qc_sub_32_re_al