### PR TITLE
Addressbus trait obj

### DIFF
--- a/emu/src/ram/loggingmem.rs
+++ b/emu/src/ram/loggingmem.rs
@@ -78,15 +78,15 @@ impl<T: OpsLogging> LoggingMem<T> {
     pub fn diffs(&self) -> DiffIter {
         self.mem.diffs()
     }
-}
 
-impl<T: OpsLogging> AddressBus for LoggingMem<T> {
-    fn copy_from(&mut self, other: &Self) {
+    pub fn copy_from(&mut self, other: &Self) {
         for (addr, byte) in other.diffs() {
             self.write_u8(addr, u32::from(byte));
         }
     }
+}
 
+impl<T: OpsLogging> AddressBus for LoggingMem<T> {
     fn read_byte(&self, address_space: AddressSpace, address: u32) -> u32 {
         let value = self.read_u8(address);
         self.logger.log(Operation::ReadByte(address_space, address & ADDRBUS_MASK, value as u8));

--- a/emu/src/ram/mod.rs
+++ b/emu/src/ram/mod.rs
@@ -42,7 +42,6 @@ pub const USER_PROGRAM: AddressSpace = AddressSpace(Mode::User, Segment::Program
 pub const USER_DATA: AddressSpace = AddressSpace(Mode::User, Segment::Data);
 
 pub trait AddressBus {
-    fn copy_from(&mut self, other: &Self);
     fn read_byte(&self, address_space: AddressSpace, address: u32) -> u32;
     fn read_word(&self, address_space: AddressSpace, address: u32) -> u32;
     fn read_long(&self, address_space: AddressSpace, address: u32) -> u32;

--- a/emu/src/ram/mod.rs
+++ b/emu/src/ram/mod.rs
@@ -51,3 +51,22 @@ pub trait AddressBus {
     fn write_long(&mut self, address_space: AddressSpace, address: u32, value: u32);
 }
 
+#[cfg(test)]
+mod tests {
+    use super::{
+        PagedMem,
+        AddressBus
+    };
+
+    #[test]
+    fn address_bus_as_trait_object() {
+        // This test will not actually test anything in runtime, but will fail
+        // if the AddressBus can't be used as a trait object.
+        //
+        // Internally in r68k, the AddressBus is not referred to as a trait object,
+        // but since AddressBus is an external API, and other projects should be
+        // able to use it as such
+        let mem = PagedMem::new(0xffffffff);
+        let _ : Box<dyn AddressBus> = Box::from(mem);
+    }
+}

--- a/emu/src/ram/pagedmem.rs
+++ b/emu/src/ram/pagedmem.rs
@@ -77,6 +77,12 @@ impl PagedMem {
     pub fn new(initializer: u32) -> PagedMem {
         PagedMem { pages: HashMap::new(), initializer }
     }
+
+    pub fn copy_from(&mut self, other: &Self) {
+        for (addr, byte) in other.diffs() {
+            self.write_u8(addr, byte as u32);
+        }
+    }
 }
 
 pub struct DiffIter<'a> {
@@ -100,12 +106,6 @@ impl<'a> Iterator for DiffIter<'a> {
 }
 
 impl AddressBus for PagedMem {
-    fn copy_from(&mut self, other: &Self) {
-        for (addr, byte) in other.diffs() {
-            self.write_u8(addr, u32::from(byte));
-        }
-    }
-
     fn read_byte(&self, _address_space: AddressSpace, address: u32) -> u32 {
         self.read_u8(address)
     }


### PR DESCRIPTION
I'm trying to use the r68k emulator (Great project!) to run some old mac applications from the 90's by creating an abstraction layer for the Macintosh toolbox.

One part of doing that is to map differnt parts of the address space, given prefixes, to differnt implementaitons. For example, one would be the video buffer, one would be the sound buffer, one would be regular RAM (possibly with memory allocation), one would be for emulade global variables.

Since it would be implemented in hardware with a demux on the MSB address bits connected to the chip enable/output enable of the different peripherals, and the lower bits as addresses, it makes sesse to treat the smaller address busses as AddressBus traits too, to keep it generic.

Therefore, I implement a MuxAddressBus, like:

```rust
pub struct PrefixMap<T> {
    // ...
}

impl<T> PrefixMap<T> {
    fn locate(&self, address : u32) -> Option<&T> {
        // ...
    }
    fn locate_mut(&mut self, address : u32) -> Option<&mut T> {
        // ...
    }
}

pub struct MuxAddressBus {
    children: PrefixMap<Box<dyn AddressBus>>
}

impl AddressBus for MuxAddressBus {
   // ...
}
```

In that way, I can split out the address space.

The problem is the copy_from() method required in the AddressBus trait, which not really corresponds to the physical interface of address lines, data lines and control lines (read/write signals). The copy_from corresponds more to a physical memory, and would be better implenented as part of that interface (LoggedMem / PagedMem).

So I suggest moving copy_from() method to the implementation of those objects, rather than the trait AddressBus